### PR TITLE
Trivial: fix missing parenthesis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Shufflepuff needs to look up address balances in order to run the protocol.
 For lite applications there is an option for querying blockcypher.com. For
 players with full nodes, an option is provided to look up balances using btcd.
 (We couldn't use bitcoin-core because it does not provide the option to index
-all addresses in the blockchain.
+all addresses in the blockchain.)
 
 Usage:
 


### PR DESCRIPTION
By the way, you can use Bitcoin Core (with addrindex) - Counterparty has been using it all along.
You can get it here:
https://github.com/btcdrak/bitcoin/releases
Installation instructions (basically just add `addrindex=1`):
https://github.com/CounterpartyXCP/Documentation/blob/master/Installation/bitcoin_core.md
Let me know if need help to test btcdrak's version.