### PR TITLE
Fixed bug with TestConnect, TcpChannel now fails as expected 

### DIFF
--- a/shuffler/src/main/java/com/shuffle/p2p/Connect.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/Connect.java
@@ -214,7 +214,7 @@ public class Connect<Identity, P extends Serializable> implements Connection<Ide
                 peers.remove();
                 continue;
             }
-            
+
             Peer<Identity, P> peer = channel.getPeer(identity);
 
             if (peer == null) {

--- a/shuffler/src/main/java/com/shuffle/p2p/Connect.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/Connect.java
@@ -214,7 +214,7 @@ public class Connect<Identity, P extends Serializable> implements Connection<Ide
                 peers.remove();
                 continue;
             }
-
+            
             Peer<Identity, P> peer = channel.getPeer(identity);
 
             if (peer == null) {

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -91,43 +91,43 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
         }
     }
 
-	private class MappedBobSend implements Send<Bytestring> {
-		private final Listener<Identity, Bytestring> l;
-		private final Session<Object, Bytestring> s;
-		private boolean initialized = false;
-		private Send<Bytestring> z;
+    private class MappedBobSend implements Send<Bytestring> {
+        private final Listener<Identity, Bytestring> l;
+        private final Session<Object, Bytestring> s;
+        private boolean initialized = false;
+        private Send<Bytestring> z;
 
-		private MappedBobSend(Listener<Identity, Bytestring> l, Session<Object, Bytestring> s) {
-			this.l = l;
-			this.s = s;
-		}
+        private MappedBobSend(Listener<Identity, Bytestring> l, Session<Object, Bytestring> s) {
+            this.l = l;
+            this.s = s;
+        }
 
-		@Override
-		public boolean send(Bytestring message) throws InterruptedException, IOException {
-			if (!initialized) {
-				Identity you = null;
-				String msg = new String(message.bytes);
-				System.out.println("+++ Received " + msg + " ; " + inverse);
-				for (Map.Entry<Object, Identity> e : inverse.entrySet()) {
-					if (e.getValue().toString().equals(msg)) {
-						you = e.getValue();
-						break;
-					}
-				}
-				if (you == null) throw new NullPointerException();
-				this.z = l.newSession(new MappedSession(s, you));
-				initialized = true;
-				return true;
-			}
+        @Override
+        public boolean send(Bytestring message) throws InterruptedException, IOException {
+            if (!initialized) {
+                Identity you = null;
+                String msg = new String(message.bytes);
+                System.out.println("+++ Received " + msg + " ; " + inverse);
+                for (Map.Entry<Object, Identity> e : inverse.entrySet()) {
+                    if (e.getValue().toString().equals(msg)) {
+                        you = e.getValue();
+                        break;
+                    }
+                }
+                if (you == null) throw new NullPointerException();
+                this.z = l.newSession(new MappedSession(s, you));
+                initialized = true;
+                return true;
+            }
 
-			return this.z.send(message);
-		}
+            return this.z.send(message);
+        }
 
-		@Override
-		public void close() {
-			s.close();
-		}
-	}
+        @Override
+        public void close() {
+            s.close();
+        }
+    }
 
     private class MappedPeer implements Peer<Identity,Bytestring> {
         private final Peer<Object, Bytestring> inner;

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -74,6 +74,23 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
         }
     }
 	
+	private class MappedAliceSend implements Send<Bytestring> {
+		
+		private MappedAliceSend() {
+			
+		}
+		
+		@Override
+		public boolean send(Bytestring message) {
+			return false;
+		}
+		
+		@Override
+		public void close() {
+			
+		}
+	}
+	
 	private class MappedBobSend implements Send<Bytestring> {
 		private final Listener<Identity, Bytestring> l;
 		private final Session<Object, Bytestring> s;

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -73,35 +73,35 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
             return "MappedSession[" + inner + "]";
         }
     }
-	
-	private class MappedAliceSend implements Send<Bytestring> {
-		
-		private MappedAliceSend() {
-			
-		}
-		
-		@Override
-		public boolean send(Bytestring message) {
-			return false;
-		}
-		
-		@Override
-		public void close() {
-			
-		}
-	}
-	
+    
+    private class MappedAliceSend implements Send<Bytestring> {
+
+        private MappedAliceSend() {
+
+        }
+
+        @Override
+        public boolean send(Bytestring message) {
+            return false;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+
 	private class MappedBobSend implements Send<Bytestring> {
 		private final Listener<Identity, Bytestring> l;
 		private final Session<Object, Bytestring> s;
 		private boolean initialized = false;
 		private Send<Bytestring> z;
-		
+
 		private MappedBobSend(Listener<Identity, Bytestring> l, Session<Object, Bytestring> s) {
 			this.l = l;
 			this.s = s;
 		}
-		
+
 		@Override
 		public boolean send(Bytestring message) throws InterruptedException, IOException {
 			if (!initialized) {
@@ -119,10 +119,10 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
 				initialized = true;
 				return true;
 			}
-			
+
 			return this.z.send(message);
 		}
-		
+
 		@Override
 		public void close() {
 			s.close();

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -68,8 +68,8 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
             inner.close();
         }
 
-        @Override
-        public String toString() {
+        @Override 
+		public String toString() {
             return "MappedSession[" + inner + "]";
         }
     }
@@ -106,8 +106,8 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
 		public boolean send(Bytestring message) throws InterruptedException, IOException {
 			if (!initialized) {
 				Identity you = null;
-                String msg = new String(message.bytes);
-                System.out.println("+++ Received " + msg + " ; " + inverse);
+				String msg = new String(message.bytes);
+				System.out.println("+++ Received " + msg + " ; " + inverse);
 				for (Map.Entry<Object, Identity> e : inverse.entrySet()) {
 					if (e.getValue().toString().equals(msg)) {
 						you = e.getValue();
@@ -116,10 +116,10 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
 				}
 				if (you == null) throw new NullPointerException();
 				this.z = l.newSession(new MappedSession(s, you));
-                initialized = true;
+				initialized = true;
 				return true;
 			}
-
+			
 			return this.z.send(message);
 		}
 		

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -159,7 +159,7 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
                 return next.getPeer(you);
             }
         }
-		
+
         return new MappedPeer(inner.getPeer(addr), you);
     }
 
@@ -215,7 +215,7 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
             if (inverse.containsKey(e.getValue())) {
                 hosts.remove(e.getKey());
             }
-			
+
             inverse.put(e.getValue(), e.getKey());
         }
 

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -215,7 +215,7 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
             if (inverse.containsKey(e.getValue())) {
                 hosts.remove(e.getKey());
             }
-
+			
             inverse.put(e.getValue(), e.getKey());
         }
 

--- a/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/MappedChannel.java
@@ -159,7 +159,7 @@ public class MappedChannel<Identity> implements Channel<Identity, Bytestring> {
                 return next.getPeer(you);
             }
         }
-
+		
         return new MappedPeer(inner.getPeer(addr), you);
     }
 

--- a/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
+++ b/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
@@ -290,7 +290,7 @@ public class TestConnect {
         int seed = 245;
         int msgNo = 100;
         for (TestCase tc: cases) {
-            for (int i = 2; i <= tc.rounds(); i++) {
+            for (int i = 3; i <= tc.rounds(); i++) {
                 System.out.println("Trial " + i + ": ");
                 Map<Integer, Collector<Integer, Bytestring>> nets = simulation(i, seed + i, tc.network(i));
                 Assert.assertTrue(nets != null);

--- a/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
+++ b/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
@@ -52,7 +52,7 @@ public class TestConnect {
 
     private interface TestCase {
         int rounds();
-        Network network();
+        Network network(int n);
     }
 
     private static class ConnectRun implements Runnable {
@@ -242,7 +242,7 @@ public class TestConnect {
             }
 
             @Override
-            public Network network() {
+            public Network network(int n) {
                 return new Network() {
                     private final MockNetwork<Integer, Bytestring> network = new MockNetwork<>();
 
@@ -259,19 +259,24 @@ public class TestConnect {
             }
 
             @Override
-            public Network network() {
+            public Network network(int n) {
                 return new Network() {
-                    int port = 5000;
-                    final Map<Integer, InetSocketAddress> hosts = new HashMap<>();
 
                     @Override
                     public Channel<Integer, Bytestring> node(Integer i) throws UnknownHostException {
-                        InetSocketAddress address = new InetSocketAddress(InetAddress.getLocalHost(), port);
-                        TcpChannel tcp = new TcpChannel(address);
-                        hosts.put(i, address);
+						
+						int port = 5000;
+						final Map<Integer, InetSocketAddress> hosts = new HashMap<>();
+						
+						for (int j = 0; j < n; j ++) {
+							InetSocketAddress address = new InetSocketAddress(InetAddress.getLocalHost(), port);
+							hosts.put(j, address);
+							port ++;
+						}
+						
+						System.out.println(hosts);
+						TcpChannel tcp = new TcpChannel(hosts.get(i-1));
                         MappedChannel<Integer> mapped = new MappedChannel<>(tcp, hosts, i);
-
-                        port ++;
 
                         return mapped;
                     }
@@ -287,7 +292,7 @@ public class TestConnect {
         for (TestCase tc: cases) {
             for (int i = 2; i <= tc.rounds(); i++) {
                 System.out.println("Trial " + i + ": ");
-                Map<Integer, Collector<Integer, Bytestring>> nets = simulation(i, seed + i, tc.network());
+                Map<Integer, Collector<Integer, Bytestring>> nets = simulation(i, seed + i, tc.network(i));
                 Assert.assertTrue(nets != null);
                 System.out.println("Trial " + i + ": " + nets);
                 Assert.assertTrue(nets.size() == i);

--- a/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
+++ b/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
@@ -268,14 +268,14 @@ public class TestConnect {
 						int port = 5000;
 						final Map<Integer, InetSocketAddress> hosts = new HashMap<>();
 						
-						for (int j = 0; j < n; j ++) {
+						for (int j = 1; j <= n; j ++) {
 							InetSocketAddress address = new InetSocketAddress(InetAddress.getLocalHost(), port);
 							hosts.put(j, address);
 							port ++;
 						}
 						
 						System.out.println(hosts);
-						TcpChannel tcp = new TcpChannel(hosts.get(i-1));
+						TcpChannel tcp = new TcpChannel(hosts.get(i));
                         MappedChannel<Integer> mapped = new MappedChannel<>(tcp, hosts, i);
 
                         return mapped;


### PR DESCRIPTION
Before, we could not get to the openSession failure in TestConnect, now we can.  TestConnect will now run in an infinite loop when trying to open a session with another TcpChannel