### PR TITLE
Fixed CryptoProtobuf

### DIFF
--- a/shuffler/src/main/java/com/shuffle/bitcoin/impl/CryptoProtobuf.java
+++ b/shuffler/src/main/java/com/shuffle/bitcoin/impl/CryptoProtobuf.java
@@ -25,6 +25,11 @@ public class CryptoProtobuf extends Protobuf {
     NetworkParameters params;
     Bitcoin bitcoin;
 
+    public CryptoProtobuf(NetworkParameters params) {
+        super();
+        this.params = params;
+    }
+
     @Override
     // Unmarshall an address from its string representation.
     public Address unmarshallAdress(String str) throws FormatException {

--- a/shuffler/src/main/java/com/shuffle/player/Shuffle.java
+++ b/shuffler/src/main/java/com/shuffle/player/Shuffle.java
@@ -363,7 +363,7 @@ public class Shuffle {
                     if (mockCrypto) {
                         m = new MockProtobuf();
                     } else {
-                        m = new CryptoProtobuf();
+                        m = new CryptoProtobuf(netParams);
                     }
                     break;
                 default:
@@ -372,7 +372,7 @@ public class Shuffle {
 
         } else {
             crypto = new BitcoinCrypto(netParams);
-            m = new CryptoProtobuf();
+            m = new CryptoProtobuf(netParams);
         }
 
         amount = (Long)options.valueOf("amount");


### PR DESCRIPTION
The CryptoProtobuf method unmarshallVerificationKey(String str) relied on a NetworkParameters member variable that was never set. Because of this, shuffles would fail if TEST_MODE was set to true and the --crypto flag was set to "real".