### PR TITLE
Otrfixes - Removed SynchronizedSessionImpl, Otr now works with TestConnect.java

### DIFF
--- a/shuffler/src/main/java/com/shuffle/p2p/Connect.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/Connect.java
@@ -239,6 +239,7 @@ public class Connect<Identity, P extends Serializable> implements Connection<Ide
                 // Maximum number of retries has prevented us from making all connections.
                 // TODO In some instances, it should be possible to run coin shuffle with fewer
                 // players, so we should still return the network object.
+                System.out.println("Reached maximum connection retry limit - could not connect to peer: " + peer.identity());
                 connection.close();
                 return null;
             }

--- a/shuffler/src/main/java/com/shuffle/p2p/OtrChannel.java
+++ b/shuffler/src/main/java/com/shuffle/p2p/OtrChannel.java
@@ -518,7 +518,7 @@ public class OtrChannel<Address> implements Channel<Address, Bytestring> {
              */
 
             Boolean result = chan.receive();
-            if (!result) {
+            if (result == null || !result) {
                 chan.close();
                 session.close();
                 return null;

--- a/shuffler/src/main/java/com/shuffle/player/Messages.java
+++ b/shuffler/src/main/java/com/shuffle/player/Messages.java
@@ -207,7 +207,7 @@ public class Messages implements MessageFactory {
         // TODO make this a parameter.
         Inbox.Envelope<VerificationKey,
                 Signed<com.shuffle.chan.packet.Packet<VerificationKey, Payload>>> e
-                = receive.receive(1000, TimeUnit.MILLISECONDS);
+                = receive.receive(10000, TimeUnit.MILLISECONDS);
 
         if (e == null) return null;
 

--- a/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
+++ b/shuffler/src/test/java/com/shuffle/p2p/TestConnect.java
@@ -125,7 +125,7 @@ public class TestConnect {
             Chan<Collector<Integer, Bytestring>> netChan = new BasicChan<>();
             this.netChan = netChan;
 
-            new Thread(new ConnectRun(conn, i, addresses, 10, netChan)).start();
+            new Thread(new ConnectRun(conn, i, addresses, 100, netChan)).start();
         }
 
         @Override
@@ -271,7 +271,7 @@ public class TestConnect {
 
             @Override
             public int rounds() {
-                return 5;
+                return 13;
             }
 
             @Override
@@ -289,7 +289,8 @@ public class TestConnect {
 						
 						System.out.println(hosts);
 						TcpChannel tcp = new TcpChannel(address);
-                        MappedChannel<Integer> mapped = new MappedChannel<>(tcp, hosts, i);
+                        OtrChannel otr = new OtrChannel(tcp);
+                        MappedChannel<Integer> mapped = new MappedChannel<>(otr, hosts, i);
 
                         return mapped;
                     }

--- a/shuffler/src/test/java/com/shuffle/p2p/TestOtrMockChannel.java
+++ b/shuffler/src/test/java/com/shuffle/p2p/TestOtrMockChannel.java
@@ -1,6 +1,5 @@
 package com.shuffle.p2p;
 
-import com.shuffle.chan.Chan;
 import com.shuffle.chan.Send;
 import com.shuffle.mock.MockNetwork;
 


### PR DESCRIPTION
In this PR, the useless SynchronizedSessionImpl class has been removed from OtrChannel.  Also fixed a simple check for null in OtrChannel's openSession method.