### PR TITLE
Mainnet network byte in SigningKeyImpl.java is wrong.

### DIFF
--- a/shuffler/src/main/java/com/shuffle/bitcoin/impl/SigningKeyImpl.java
+++ b/shuffler/src/main/java/com/shuffle/bitcoin/impl/SigningKeyImpl.java
@@ -51,7 +51,7 @@ public class SigningKeyImpl implements SigningKey {
         }
 
         switch (stripped.bytes[0]) {
-            case (-1) : {
+            case (-128) : {
                 params = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
                 break;
             }


### PR DESCRIPTION
If you look at the mainnet private key address prefix (https://en.bitcoin.it/wiki/List_of_address_prefixes), it is 128, not 255.  The SigningKeyImpl.java code implies that the address prefix is 255 (stripped.bytes[0] = -1).